### PR TITLE
Working with robots under a different namespace

### DIFF
--- a/launch/robot_kinematic_services.launch
+++ b/launch/robot_kinematic_services.launch
@@ -2,7 +2,7 @@
   <node name="kinematic_services" type="kinematic_services" pkg="robot_kinematic_services" output="screen">
     <rosparam file="$(find robot_kinematic_services)/config/solver.yaml" command="load"/>
     <rosparam>
-      robot_chain_base_link: torso_lift_link
+      robot_chain_base_link: base_link
     </rosparam>
   </node>
 </launch>

--- a/src/kinematic_services.cpp
+++ b/src/kinematic_services.cpp
@@ -8,8 +8,10 @@ KinematicServices::KinematicServices() : nh_("~")
   {
     throw std::runtime_error("ERROR getting Kinematic services parameters");
   }
-
-  state_sub_ = nh_.subscribe("/joint_states", 1000,
+  std::string ns = ros::this_node::getNamespace();
+  std::string joint_states_topic = ns + "/joint_states";
+  ROS_INFO_STREAM("Listening to joint_states messages on topic: " << joint_states_topic);
+  state_sub_ = nh_.subscribe(joint_states_topic, 1000,
                              &KinematicServices::stateCallback, this);
 }
 
@@ -181,10 +183,10 @@ int main(int argc, char** argv)
   robot_kinematic_services::KinematicServices service_handler;
 
   ros::ServiceServer ik_server = nh.advertiseService(
-      "/compute_ik", &robot_kinematic_services::KinematicServices::ikCallback,
+      "compute_ik", &robot_kinematic_services::KinematicServices::ikCallback,
       &service_handler);
   ros::ServiceServer fk_server = nh.advertiseService(
-      "/compute_fk", &robot_kinematic_services::KinematicServices::fkCallback,
+      "compute_fk", &robot_kinematic_services::KinematicServices::fkCallback,
       &service_handler);
 
   ROS_INFO("Kinematic services node is ready");


### PR DESCRIPTION
To work with robot running in their own namespace (like multiple identical robot arms), the joint_states must be relative not global. And we also advertise the kinematic services under the same namespace.
Modified the launch file so that the base link is base_link